### PR TITLE
Fix NPE when using default initiator credentials

### DIFF
--- a/src/java/edu/mit/jgss/GSSContextImpl.java
+++ b/src/java/edu/mit/jgss/GSSContextImpl.java
@@ -109,6 +109,10 @@ public class GSSContextImpl implements GSSContext {
         if (myCred != null) {
             this.credential = (GSSCredentialImpl) myCred;
             this.srcName = (GSSNameImpl) myCred.getName();
+        } else {
+            /* create GSS_C_NO_CREDENTIAL */
+            this.credential =  new GSSCredentialImpl();
+            this.credential.setInternGSSCred(null);
         }
 
         if (lifetime >= 0) {


### PR DESCRIPTION
The JGSS interface allows calls to GSSManager.createContext with
default initiator credentials by passing null as the input
GSSCredentials argument. We were not correctly handling this case.
